### PR TITLE
Feature: Custom configs for mypy and pylint

### DIFF
--- a/buildpy/lint.py
+++ b/buildpy/lint.py
@@ -66,11 +66,13 @@ class PrettyReporter(CollectingReporter):
 @click.option('-d', '--directory', 'directory', required=False, type=str)
 @click.option('-o', '--output-file', 'outputFilename', required=False, type=str)
 @click.option('-f', '--output-format', 'outputFormat', required=False, type=str, default='pretty')
-def run(directory: str, outputFilename: str, outputFormat: str) -> None:
+@click.option('-c', '--config-file-path', 'configFilePath', required=False, type=str)
+def run(directory: str, outputFilename: str, outputFormat: str, configFilePath: str) -> None:
     currentDirectory = os.path.dirname(os.path.realpath(__file__))
     targetDirectory = os.path.abspath(directory or os.getcwd())
     reporter = GitHubAnnotationsReporter() if outputFormat == 'annotations' else PrettyReporter()
-    run_pylint([f'--rcfile={currentDirectory}/pylintrc', targetDirectory], reporter=reporter, exit=False)
+    pylintConfigFilePath = configFilePath or f'{currentDirectory}/pylintrc'
+    run_pylint([f'--rcfile={pylintConfigFilePath}', targetDirectory], reporter=reporter, exit=False)
     output = reporter.create_output()  # type: ignore
     if outputFilename:
         with open(outputFilename, 'w') as outputFile:

--- a/buildpy/type_check.py
+++ b/buildpy/type_check.py
@@ -89,13 +89,15 @@ class PrettyReporter(KibaReporter):
 @click.option('-d', '--directory', 'directory', required=False, type=str)
 @click.option('-o', '--output-file', 'outputFilename', required=False, type=str)
 @click.option('-f', '--output-format', 'outputFormat', required=False, type=str, default='pretty')
-def run(directory: str, outputFilename: str, outputFormat: str) -> None:
+@click.option('-c', '--config-file-path', 'configFilePath', required=False, type=str)
+def run(directory: str, outputFilename: str, outputFormat: str, configFilePath: str) -> None:
     currentDirectory = os.path.dirname(os.path.realpath(__file__))
     targetDirectory = os.path.abspath(directory or os.getcwd())
     reporter = GitHubAnnotationsReporter() if outputFormat == 'annotations' else PrettyReporter()
     messages = []
+    mypyConfigFilePath = configFilePath or f'{currentDirectory}/mypy.ini'
     try:
-        subprocess.check_output(f'mypy {targetDirectory} --config-file {currentDirectory}/mypy.ini --no-color-output --no-error-summary --show-column-numbers', stderr=subprocess.STDOUT, shell=True)
+        subprocess.check_output(f'mypy {targetDirectory} --config-file {mypyConfigFilePath} --no-color-output --no-error-summary --show-column-numbers', stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError as exception:
         messages = exception.output.decode().split('\n')
     output = reporter.create_output(messages=messages)  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(setupDirectory, 'requirements.txt'), 'r') as requirements
 
 setup(
     name='kiba-build',
-    version='0.1.3',
+    version='0.1.2',
     description='Kiba Labs\' python building and testing utilities',
     url='https://github.com/kibalabs/build-py',
     packages=find_packages(exclude=['tests*']),

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(setupDirectory, 'requirements.txt'), 'r') as requirements
 
 setup(
     name='kiba-build',
-    version='0.1.2',
+    version='0.1.3',
     description='Kiba Labs\' python building and testing utilities',
     url='https://github.com/kibalabs/build-py',
     packages=find_packages(exclude=['tests*']),


### PR DESCRIPTION
Ideally we'd have config files that extend the defaults that have already been defined (so that users of this library don't have to have huge configs!). Currently this is not possible with using standard features, but pylint are looking at implementing at the moment (https://github.com/PyCQA/pylint/issues/618, https://github.com/PyCQA/pylint/issues/618#issuecomment-366486086). 

Looks like mypy have no plans at implementing config extensions any time soon (https://mypy.readthedocs.io/en/stable/config_file.html). 